### PR TITLE
Fixing build on android: removed createJSModules

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNSqlite2Package.java
+++ b/android/src/main/java/com/reactlibrary/RNSqlite2Package.java
@@ -17,11 +17,6 @@ public class RNSqlite2Package implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();
     }


### PR DESCRIPTION
In react-native 0.47 there is no `createJSModules` method anymore to override in `android/src/main/java/com/reactlibrary/RNSqlite2Package.java`. I removed it since it is causing a build error. :)